### PR TITLE
Update custom error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - 17
 script:
   - npm run dist
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,7 +4,7 @@ export class CustomError extends Error {
   extra: unknown;
 
   constructor(statusCode: number, error?: string, extra?: unknown) {
-    super('CustomError');
+    super(error || 'CustomError');
     this.statusCode = statusCode;
     this.error = error;
     this.extra = extra


### PR DESCRIPTION
In the `CustomError` class, we currently extend `Error` and call `super('Custom Error')`. This ends up setting `Error.message = 'Custom Error`. We then set `this.error =  error` where the `error` variable is the message passed in from the caller.

The problem with this is that some tools only look at `error.message` when displaying errors. This is not very useful when debugging since there's a more detailed message passed in.
 
This PR updates the `CustomError` constructor to call `super` with the detailed `error` variable if it exists. If not, it defaults to using `'Custom Error'`.