### PR TITLE
Preserve original names when wrapping middleware functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/async.ts
+++ b/src/async.ts
@@ -139,6 +139,11 @@ const mapMiddleware = <TEntities extends Entities>(
 
   copyDecorators(middleware, fn);
 
+  // Set the wrapper function's name to the original function's name. When using
+  // observability tools that record function names, this helps identify the
+  // original function.
+  Object.defineProperty(fn, 'name', { value: middleware.name });
+
   return fn;
 };
 


### PR DESCRIPTION
Preserve the original function's name when wrapping a middleware function. When using observability tools that record function names, this helps identify the original function.