### PR TITLE
Add context parameter to schema validation error function

### DIFF
--- a/features/advanced.feature
+++ b/features/advanced.feature
@@ -133,6 +133,26 @@ Scenario: create a user without name
     }
     """
 
+Scenario: custom schema validation error function
+  Given the request header x-include-all-schema-errors is "1"
+  When POST /users
+  Then the response is 400 and the payload includes
+    """
+    {
+      "all": [
+        {
+          "expected": "string",
+          "key": ["name"]
+        },
+        {
+          "expected": "string",
+          "key": ["username"]
+        }
+      ],
+      "error": "INVALID_PAYLOAD"
+    }
+    """
+
 Scenario: get invalid user
   When GET /users/invalid
   Then the response is 404 and the payload at error is "USER"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -30,6 +30,7 @@ const createMiddleware = <TEntities extends Entities>(
   validate: ValidateSchema,
   generateError: GenerateSchemaErrorFn,
   source: RequestScope,
+  context: Context,
 ): Middleware<TEntities> =>
     (req, res, next) => {
       const realSource = source || METHOD_SOURCE_MAP[req.method.toLowerCase()];
@@ -38,7 +39,12 @@ const createMiddleware = <TEntities extends Entities>(
       const schemaErrors = validate(data);
 
       if (schemaErrors.length) {
-        res.status(400).send(generateError(schemaErrors, realSource));
+        res.status(400).send(
+          generateError(schemaErrors, realSource, {
+            ...context,
+            req,
+          }),
+        );
         return;
       }
 
@@ -66,6 +72,7 @@ export default <TEntities extends Entities, TSchema>(
     compileSchema(schema.$schema || schema, context),
     generateError,
     source,
+    context,
   );
 
   schemaMiddleware.$noOrder = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ export interface Context {
   path?: string;
 }
 
+export interface ErrorContext extends Context {
+  req: Request;
+}
+
 export interface Entities {
   _: unknown;
 }
@@ -91,6 +95,7 @@ export type CompileSchema<T> = (
 export type GenerateSchemaErrorFn = (
   errors: ValidationError[],
   source: string,
+  context: ErrorContext,
 ) => any;
 
 export type ErrorHandlerFn<TEntities extends Entities> = (


### PR DESCRIPTION
Add a context parameter to schema validation error functions. The context includes the request object to enable customizing the error response based on properties of the request.