### PR TITLE
Add OpenAPI specs decorator

### DIFF
--- a/features/advanced.feature
+++ b/features/advanced.feature
@@ -111,6 +111,10 @@ Scenario: NOT CustomResponse with headers prop, should not add headers
   And the response headers at header1 is undefined
   And the response headers at header2 is undefined
 
+Scenario: assign specs decorator
+  When GET /specs
+  Then the response is 200 and the payload is { "value": "test" }
+
 # Edges
 
 Scenario: create a user without username

--- a/features/order.feature
+++ b/features/order.feature
@@ -31,3 +31,8 @@ Scenario: reorder (loader with requires, permission does not require complex loa
 Scenario: reorder (complex permission)
   When ordering ["can(a,b)", "load(b)", "load(a)"]
   Then the ordered middlewares are ["load(a)", "load(b)", "can(a,b)"]
+
+Scenario: a spec should not be part of the middlewares
+  Given a spec "sp" with value { "operatorId": "getData" } 
+  When ordering ["load(b)", "can(b)", "load(a)", "sp"]
+  Then the ordered middlewares are ["load(b)", "can(b)", "load(a)"]

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -33,6 +33,7 @@ export interface Route<TSchema> {
   path: string;
   permissions: string[];
   schema?: TSchema;
+  specs?: object;
   successStatus: number;
   summary: string;
 }
@@ -71,6 +72,7 @@ class MetadataApp<TSchema> {
       const middlewares = other.filter(isMiddleware);
       const deprecated = middlewares.find(m => !!m.$deprecated);
       const permissions = this.permissions.concat(getPermissions(middlewares));
+      const specs = middlewares.find(m => !!m.$specs);
 
       this.routes.push({
         deprecated: deprecated && deprecated.$deprecated,
@@ -81,6 +83,7 @@ class MetadataApp<TSchema> {
         schema: (this.schema || schema)
           ? Object.assign({}, this.schema, schema)
           : undefined,
+        specs: specs && specs.$specs,
         successStatus,
         summary,
       });

--- a/src/decorate.ts
+++ b/src/decorate.ts
@@ -14,3 +14,4 @@ const set = <T extends keyof Decorator>(key: T) =>
 export const permission = set('$permission');
 export const provides = set('$provides');
 export const requires = set('$requires');
+export const specs = set('$specs');

--- a/src/examples/advanced/app.ts
+++ b/src/examples/advanced/app.ts
@@ -7,7 +7,7 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import { join } from 'path';
 
-import { deprecate } from '../..';
+import { badRequest, deprecate, specs } from '../..';
 import { createCustomResponse } from '../../custom-response';
 import createApp, { Req } from './async-app';
 import can from './can';
@@ -147,6 +147,18 @@ app.get('/response-headers', () => ({
   },
   value: 'test',
 }));
+
+// The specs decorator set a value for future purpose like OpenAPI
+// specs generation.
+app.get(
+  '/specs',
+  'Test specs decorator',
+  specs({ operatorId: 'getData' }, (_: Req) => {
+    // This middleware should not run when calling the endpoint.
+    throw badRequest('WRONG_EXEC');
+  }),
+  (_: Req) => ({ value: 'test' }),
+);
 
 // --- Docs ----------------------------------------------------------- //
 app.use(

--- a/src/order.ts
+++ b/src/order.ts
@@ -132,7 +132,7 @@ export default <TEntities extends Entities, TSchema>() => (
   // should not be ordered.
   const orderedMiddlewares: Middleware<TEntities>[] = [...noOrder];
   const addMiddleware = (m: Middleware<TEntities>) => {
-    if (!orderedMiddlewares.includes(m)) {
+    if (!m.$specs && !orderedMiddlewares.includes(m)) {
       orderedMiddlewares.push(m);
     }
   };

--- a/src/test.ts
+++ b/src/test.ts
@@ -65,6 +65,13 @@ const setup: SetupFn = ({ compare, getCtx, Given, setCtx, Then, When }) => {
     (op, expected) => compare(op, DB, expected),
     { inline: true },
   );
+  // === Specs ============================================================== //
+  Given(
+    'a spec "{word}" with value (.*)',
+    (name, specs) => addMiddleware(name, {
+      $specs: JSON.parse(specs),
+    }),
+  );
 };
 
 pickledCucumber(setup, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type Decorator = {
   $permission?: string;
   $noOrder?: boolean;
   $deprecated?: 'in-use' | 'redirect' | 'rewrite';
+  $specs?: object;
 };
 
 export type CommonMiddleware<TEntities extends Entities> = (


### PR DESCRIPTION
Adds an OpenAPI specs decorator.

Endpoints could add a new decoration and send data to be consumed by the `analyze` method.

On the app side, we can add a new wrapper like:

```
import { specs } from 'async-app';
import { Middleware, Req } from './app';

export type SpecsMetadata = {
  operationId?: string;
};

const specsMiddleware: Middleware = (_req: Req<null>, _res, next) => {
  next();
};

export const openApi = (spec: SpecsMetadata) => specs(spec, specsMiddleware);

```

And then use it like:
```
app.get(
  '/todos/:todoId',
  'Returns the specified todo item',
  openApi({ operationId: 'getTodoById' }),
  ...
```

When we call the analyze, we'll be able to access to the `specs` of each `Route`.
