### PR TITLE
Add information to the analyze module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/examples/advanced/app.ts
+++ b/src/examples/advanced/app.ts
@@ -51,6 +51,10 @@ app.post(
     name: 'string',
     username: 'string',
   },
+  { // This is the expected schema of the response (optional)
+    $scope: 'response',
+    username: 'string',
+  },
   async (req: Req) => {
     const user = req.body;
     await addUser(user);
@@ -115,7 +119,13 @@ app.get(
 
 app.get('/echo1', () => 'echo');
 
-app.get('/echo2', () => 'echo', () => ({ last: true }));
+app.get(
+  '/echo2',
+  // The expected schema of the query parameters
+  { 'throw?': '"true"|"false"' },
+  () => 'echo',
+  () => ({ last: true }),
+);
 
 app.get('/echo3', (_, res) => {
   setTimeout(() => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,7 +11,7 @@ import {
   ValidateSchema,
 } from './types';
 
-const METHOD_SOURCE_MAP: { [key: string]: Scope } = {
+export const METHOD_SOURCE_MAP: { [key: string]: Scope } = {
   delete: 'query',
   get: 'query',
   patch: 'body',


### PR DESCRIPTION
### Analyze module

- When an endpoint defines a response schema, include the schema in the output of the analyze module.
- Add information about where the endpoint is defined in the source code including the absolute filename and line number of the endpoint definition. External tools can use this information to parse supplemental endpoint metadata from the source code, for example.

### Swagger module

-  Include query parameters and the response schema for successful responses in the Swagger document.

### Advanced example app

- Demonstrate a query parameter schema and a response schema. Both appear in the generated API documentation:

  ![image](https://github.com/muralco/async-app/assets/7122091/26e916df-3085-4e4a-85d9-2b032eea2c96)
  ![image](https://github.com/muralco/async-app/assets/7122091/f695d01d-5937-42de-b633-449115273097)
