### PR TITLE
Fix remove the landmines from the CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,12 @@ jobs:
         run: |
           npm ci
 
-      - name: Build and test 
-        run: |
-          npm run dist
+      - run: npm run lint
+      - run: npm run test
 
       - name: Publish 
         if: ${{github.ref == 'refs/heads/master'}}
-        working-directory: dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm publish
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "async-app",
-  "version": "4.6.0",
+  "version": "4.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "async-app",
-      "version": "4.6.0",
+      "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
         "express": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -49,13 +49,12 @@
     "lodash": "^4.17.11"
   },
   "scripts": {
-    "build": "npm run lint && tsc",
-    "dist": "rm -rf dist && tsc",
+    "build": "tsc",
+    "dist": "rm -rf dist && npm run build",
     "lint": "tslint -p .",
-    "prepublishOnly": "npm run lint",
-    "prepack": "npm run test",
     "test": "cucumber-js --require-module ts-node/register --exit -r src/test.ts",
     "watch": "tsc -w",
+    "prepack": "npm run test",
     "prepare": "npm run dist"
   }
 }


### PR DESCRIPTION
This PR removes the `working-directory` directive from the CD pipeline.

The reasoning is that in order to make `async-app` installable from sources, it is easier to keep the same structure in the packed tarball.

There was quite a bit of shinanegans around removing/copying files into `dist/` and the last piece of the puzzle was the CD pipeline using the `dist/` folder as the publishing root.

Everything is simpler now.