### PR TITLE
Add support for array and union response schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/async.ts
+++ b/src/async.ts
@@ -158,8 +158,13 @@ export default <TEntities extends Entities, TSchema>({
     const schema = args
       .filter(isSchema<TSchema>())
       .find(s => s.$scope === 'response');
+    const rawSchema = schema
+      ? schema.$schema
+        ? schema.$schema
+        : schema
+      : undefined;
     const validateSchema =
-      compileSchema && schema && compileSchema(schema, context);
+      compileSchema && rawSchema && compileSchema(rawSchema, context);
 
     const middlewares = args.filter(isMiddleware);
     const lastMiddleware = middlewares[middlewares.length - 1];

--- a/src/examples/advanced/app.ts
+++ b/src/examples/advanced/app.ts
@@ -95,6 +95,15 @@ app.post(
 app.get(
   '/todos/:username',
   'Returns the TODOs for the specified user',
+  {
+    $schema: [{
+      id: 'number',
+      item: 'string',
+      owner: 'string',
+      readOnly: 'boolean',
+    }],
+    $scope: 'response',
+  },
   load.user.fromParams(),
   (req: Req<'user'>) => getTodosForUser(req.user.username),
 );

--- a/src/examples/advanced/app.ts
+++ b/src/examples/advanced/app.ts
@@ -121,8 +121,12 @@ app.get('/echo1', () => 'echo');
 
 app.get(
   '/echo2',
-  // The expected schema of the query parameters
-  { 'throw?': '"true"|"false"' },
+  // The expected schema of the query parameters.
+  // $scope is optional. When unspecified, it's inferred from the method.
+  {
+    $scope: 'query',
+    'throw?': '"true"|"false"',
+  },
   () => 'echo',
   () => ({ last: true }),
 );

--- a/src/examples/advanced/async-app.ts
+++ b/src/examples/advanced/async-app.ts
@@ -88,4 +88,6 @@ export default (errorHandlerFn?: ErrorHandlerFn<ExampleEntities>) =>
         path: req.path,
       };
     },
+    // The following line enables schema validation for responses.
+    validateResponseSchema: true,
   });

--- a/src/examples/advanced/async-app.ts
+++ b/src/examples/advanced/async-app.ts
@@ -9,6 +9,7 @@
 // | help us in specifing middlewares later.                                | //
 // +========================================================================+ //
 
+import { omit } from 'lodash';
 import { parseSchema, Type } from 'mural-schema';
 import { ToDo, User } from './db';
 
@@ -63,7 +64,10 @@ export default (errorHandlerFn?: ErrorHandlerFn<ExampleEntities>) =>
     // The following line enables schema validation using `mural-schema`. Note
     // that you can easily change your schema validation module by specifing add
     // different `compileSchemaFn`.
-    compileSchemaFn: schema => parseSchema(schema),
+    compileSchemaFn: schema =>
+      parseSchema(
+        schema.$scope !== undefined ? omit(schema, '$scope') : schema,
+      ),
     errorHandlerFn,
     // The following line registers a function that maps schema validation
     // errors to an error response payload. When not specified, async-app uses a


### PR DESCRIPTION
Input schemas support array and union schemas by nesting the schema under the `$schema` key:

```js
{
  $schema: ['string']
}
```

Add `$schema` support for response schemas:

```js
{
  $scope: 'response',
  $schema: ['string']
}
```