### PR TITLE
Add response schema log support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,36 @@ const { parseSchema } = require('mural-schema');
 const app = createApp({ compileSchemaFn: parseSchema });
 ```
 
+### Response validation
+
+You can validate response bodies by adding a schema with `$scope: 'response'` to the
+endpoint and enabling response validation in `createApp`:
+
+```js
+app.get(
+  '/users/:id',
+  {
+    $scope: 'response',
+    id: 'string',
+    name: 'string',
+  },
+  req => getUserById(req.params.id),
+);
+```
+
+Options in `createApp`:
+
+- **`validateResponseSchema`** (boolean) – When `true`, responses that fail the
+  response schema are rejected with HTTP 400 and a payload
+  `{ error: 'INVALID_SCHEMA_RESPONSE', path, source: 'response' }`. When `false`
+  or omitted (e.g. in production), response schema validation is skipped.
+- **`logResponseSchemaErrorsFn`** (optional) – Callback invoked when a response
+  fails schema validation: `(method, path, errors, value) => void`. Useful for
+  logging or metrics. The `path` argument is the **route pattern** (e.g.
+  `/users/:id`), not the actual request path, so you can aggregate by route.
+  This callback can be used with or without `validateResponseSchema` (e.g. log
+  in production without returning 400).
+
 ## Error handling
 
 `async-app` provides a set of error functions you can throw from your

--- a/features/advanced.feature
+++ b/features/advanced.feature
@@ -207,6 +207,18 @@ Scenario: deprecate.rewrite get todos
   And the response headers at deprecated-for is "GET /todos/${U.username}"
   And the response headers at location contains "/todos/${U.username}"
 
+Scenario: logResponseSchemaErrorsFn is called with route pattern path on invalid response schema
+  Given clear logResponseSchemaErrorsFn calls
+  When GET /log-response-schema-test/abc123
+  Then the response is 400 and the payload includes
+    """
+    {
+      "error": "INVALID_SCHEMA_RESPONSE",
+      "source": "response"
+    }
+    """
+  And logResponseSchemaErrorsFn was called once with path containing "/log-response-schema-test/:id"
+
 # Compute permissions
 
 Scenario: get positive TODO permissions

--- a/features/analyze.feature
+++ b/features/analyze.feature
@@ -35,4 +35,4 @@ Scenario: analyze basic app
 Scenario: analyze advanced app succeeds
   Given an advanced app
   When analyzing the current app
-  Then the analyzed routes at length is 18
+  Then the analyzed routes at length is 19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-app",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "An express wrapper for handling async middlewares, order middlewares, schema validator, and other stuff",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/async.ts
+++ b/src/async.ts
@@ -12,6 +12,7 @@ import {
   isNumber,
   isPromise,
   isSchema,
+  LogResponseSchemaErrorsFn,
   MapAsyncResultFn,
   Middleware,
   ValidateSchema,
@@ -23,13 +24,19 @@ interface AsyncOptions<TEntities extends Entities, TSchema> {
   compileSchema?: CompileSchema<TSchema>;
   errorHandler?: ErrorHandlerFn<TEntities>;
   mapAsyncResultFn?: MapAsyncResultFn<TEntities>;
+  logResponseSchemaErrorsFn?: LogResponseSchemaErrorsFn;
+  validateResponseSchema?: boolean;
 }
 
 type Options<TEntities extends Entities> =  {
   statusCode: number;
   isLastMiddleware: boolean;
-  validateSchema?: ValidateSchema;
+  validateSchemaFn?: ValidateSchema;
   mapAsyncResultFn?: MapAsyncResultFn<TEntities>;
+  logResponseSchemaErrorsFn?: LogResponseSchemaErrorsFn;
+  // Route pattern, not the actual request path
+  routePath?: string;
+  validateResponseSchema?: boolean;
 };
 
 const copyDecorators = <TSrc extends Decorator, TDest extends Decorator>(
@@ -97,19 +104,32 @@ const mapMiddleware = <TEntities extends Entities>(
       // The middleware already responded so there's nothing for us to do
       if (res.headersSent) return;
 
-      if (options.validateSchema) {
-        // Lets validate that schema
-        const schemaErrors = options.validateSchema(val);
+      if (options.validateSchemaFn) {
+        const schemaErrors = options.validateSchemaFn(val);
 
         if (schemaErrors.length) {
-          const response = {
-            error: 'INVALID_SCHEMA_RESPONSE',
-            path: schemaErrors[0].key,
-            source: 'response',
-          };
+          if (options.logResponseSchemaErrorsFn) {
+            const path = options.routePath != null
+            ? `${req.baseUrl || ''}${options.routePath}`
+            : `${req.baseUrl}${req.path}`;
 
-          res.status(400).send(response);
-          return;
+            options.logResponseSchemaErrorsFn(
+              req.method,
+              path,
+              schemaErrors,
+              val,
+            );
+          }
+          if (options.validateResponseSchema) {
+            const response = {
+              error: 'INVALID_SCHEMA_RESPONSE',
+              path: schemaErrors[0].key,
+              source: 'response',
+            };
+
+            res.status(400).send(response);
+            return;
+          }
         }
       }
 
@@ -151,6 +171,8 @@ export default <TEntities extends Entities, TSchema>({
     errorHandler,
     compileSchema,
     mapAsyncResultFn,
+    logResponseSchemaErrorsFn,
+    validateResponseSchema,
   }: AsyncOptions<TEntities, TSchema> = {}): Converter<TEntities, TSchema> =>
   (args, context) => {
     const statusCode = args.find(isNumber) || DEFAULT_STATUS_CODE;
@@ -163,8 +185,12 @@ export default <TEntities extends Entities, TSchema>({
         ? schema.$schema
         : schema
       : undefined;
-    const validateSchema =
-      compileSchema && rawSchema && compileSchema(rawSchema, context);
+    const willUseResponseSchema =
+      validateResponseSchema || logResponseSchemaErrorsFn;
+    const validateSchemaFn =
+      willUseResponseSchema && compileSchema && rawSchema
+        ? compileSchema(rawSchema, context)
+        : undefined;
 
     const middlewares = args.filter(isMiddleware);
     const lastMiddleware = middlewares[middlewares.length - 1];
@@ -177,9 +203,12 @@ export default <TEntities extends Entities, TSchema>({
           // Check if this is the last valid middleware (not the statusCode arg)
           {
             isLastMiddleware: m === lastMiddleware,
+            logResponseSchemaErrorsFn,
             mapAsyncResultFn,
+            routePath: context.path,
             statusCode,
-            validateSchema,
+            validateResponseSchema,
+            validateSchemaFn,
           },
           // Passes a custom error handler
           errorHandler,

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -88,12 +88,11 @@ const asyncAppProvider: AppProvider = <
   }
 
   const async = asyncConverter<TEntities, TSchema>({
-    compileSchema:
-      opts && opts.compileSchemaFn && opts.validateResponseSchema
-        ? opts.compileSchemaFn
-        : undefined,
+    compileSchema: opts && opts.compileSchemaFn,
     errorHandler: opts && opts.errorHandlerFn ? opts.errorHandlerFn : undefined,
+    logResponseSchemaErrorsFn: opts && opts.logResponseSchemaErrorsFn,
     mapAsyncResultFn: opts && opts.mapAsyncResultFn,
+    validateResponseSchema: opts && opts.validateResponseSchema,
   });
 
   METHODS.forEach(m =>

--- a/src/examples/advanced/app.ts
+++ b/src/examples/advanced/app.ts
@@ -134,6 +134,21 @@ app.get(
     computePermissions(entities, 'todo', { todo: req.todo, user: req.user }),
 );
 
+// Route for testing logResponseSchemaErrorsFn, returns data that fails
+// response schema validation
+app.get(
+  '/log-response-schema-test/:id',
+  {
+    $scope: 'response',
+    id: 'number',
+    name: 'string',
+  },
+  (req: Req) => ({
+    id: req.params.id,
+    name: 123,
+  }),
+);
+
 app.get('/echo1', () => 'echo');
 
 app.get(

--- a/src/examples/advanced/async-app.ts
+++ b/src/examples/advanced/async-app.ts
@@ -17,8 +17,13 @@ import { ToDo, User } from './db';
 import createApp, {
   Entities,
   internalServerError,
-  Req as Request } from '../..';
-import { ErrorHandlerFn, GenerateSchemaErrorFn } from '../../types';
+  Req as Request,
+} from '../..';
+import {
+  ErrorHandlerFn,
+  GenerateSchemaErrorFn,
+  LogResponseSchemaErrorsFn,
+} from '../../types';
 
 // This type represents all the custom `req` keys that we could have, in this
 // example those are `res.user` and `req.todo`.
@@ -56,6 +61,24 @@ const generateSchemaErrorFn: GenerateSchemaErrorFn = (
   };
 };
 
+export const lastLogResponseSchemaErrorsCalls: {
+  method: string;
+  path: string;
+  errors: { expected?: string; key: (string | number)[] }[];
+  value: unknown;
+}[] = [];
+
+const logResponseSchemaErrorsFn: LogResponseSchemaErrorsFn = (
+  method,
+  path,
+  errors,
+  value,
+) => {
+  // Capture logResponseSchemaErrorsFn calls for tests,
+  // reset between scenarios
+  lastLogResponseSchemaErrorsCalls.push({ method, path, errors, value });
+};
+
 // This function replaces `express()` as in `const app = express()`;
 export default (errorHandlerFn?: ErrorHandlerFn<ExampleEntities>) =>
   createApp<ExampleEntities, Type>({
@@ -73,6 +96,7 @@ export default (errorHandlerFn?: ErrorHandlerFn<ExampleEntities>) =>
     // errors to an error response payload. When not specified, async-app uses a
     // built-in schema validation error function.
     generateSchemaErrorFn,
+    logResponseSchemaErrorsFn,
     mapAsyncResultFn: async (value, { req, ...opts }) => {
       if (value !== 'echo') return value;
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,6 +3,8 @@ import pickledCucumber, { SetupFn } from 'pickled-cucumber';
 import httpSupertest from 'pickled-cucumber/http/supertest';
 import supertest from 'supertest';
 import advancedApp from './examples/advanced/app';
+import { lastLogResponseSchemaErrorsCalls } from
+  './examples/advanced/async-app';
 import { DB } from './examples/advanced/db';
 import { entities } from './examples/advanced/test';
 import orderMiddlewares from './order';
@@ -89,6 +91,27 @@ const setup: SetupFn = ({ compare, getCtx, Given, setCtx, Then, When }) => {
     { inline: true },
   );
   // === Advanced example =================================================== //
+  Given('clear logResponseSchemaErrorsFn calls', () => {
+    lastLogResponseSchemaErrorsCalls.length = 0;
+  });
+  Then(
+    'logResponseSchemaErrorsFn was called once with path containing "(.*)"',
+    (pathSubstring: string) => {
+      const calls = lastLogResponseSchemaErrorsCalls;
+      if (calls.length !== 1) {
+        throw new Error(
+          `Expected logResponseSchemaErrorsFn to be called once, ` +
+          `got ${calls.length}`,
+        );
+      }
+      const path = calls[0].path;
+      if (!path.includes(pathSubstring)) {
+        throw new Error(
+          `Expected path to contain "${pathSubstring}", got "${path}"`,
+        );
+      }
+    },
+  );
   Then(
     'the DB {op}',
     (op, expected) => compare(op, DB, expected),

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,13 @@ export type ErrorHandlerFn<TEntities extends Entities> = (
   next: NextFunction,
 ) => any;
 
+export type LogResponseSchemaErrorsFn = (
+  method: string,
+  path: string,
+  errors: ValidationError[],
+  value: unknown,
+) => void;
+
 // === Arguments ============================================================ //
 export type MiddlewareArg<TEntities extends Entities> =
   | CommonMiddleware<TEntities>
@@ -167,6 +174,7 @@ export interface Opts<
   compileSchemaFn?: CompileSchema<TSchema>;
   generateSchemaErrorFn?: GenerateSchemaErrorFn;
   errorHandlerFn?: ErrorHandlerFn<TEntities>;
+  logResponseSchemaErrorsFn?: LogResponseSchemaErrorsFn;
   validateResponseSchema?: boolean;
   mapAsyncResultFn?: MapAsyncResultFn<TEntities>;
 }


### PR DESCRIPTION
Adds support for logging response-schema validation failures (including the route pattern) via a new logResponseSchemaErrorsFn option, with accompanying docs and cucumber coverage.

Changes:

Introduces logResponseSchemaErrorsFn in public options/types and wires it through app creation into the async converter.
Extends response-schema handling to optionally log schema errors and/or reject invalid responses with HTTP 400.
Adds an advanced-example route + cucumber steps/scenario to verify the callback is invoked with a route-pattern path; updates docs and version.